### PR TITLE
feat: support custom KV impls

### DIFF
--- a/balius-runtime/src/kv/mod.rs
+++ b/balius-runtime/src/kv/mod.rs
@@ -1,23 +1,48 @@
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
 use crate::wit::balius::app::kv as wit;
+
+pub use wit::{Host as CustomKv, KvError, Payload};
 
 #[derive(Clone)]
 pub enum Kv {
     Mock,
+    Custom(Arc<Mutex<dyn wit::Host + Send + Sync>>),
 }
 
 #[async_trait::async_trait]
 impl wit::Host for Kv {
-    async fn get_value(&mut self, key: String) -> Result<wit::Payload, wit::KvError> {
-        todo!()
+    async fn get_value(&mut self, key: String) -> Result<Payload, KvError> {
+        match self {
+            Self::Mock => todo!(),
+            Self::Custom(kv) => {
+                let mut lock = kv.lock().await;
+                lock.get_value(key).await
+            }
+        }
     }
 
-    async fn set_value(&mut self, key: String, value: wit::Payload) -> Result<(), wit::KvError> {
-        println!("{}:{}", key, hex::encode(value));
-
-        Ok(())
+    async fn set_value(&mut self, key: String, value: Payload) -> Result<(), KvError> {
+        match self {
+            Self::Mock => {
+                println!("{}:{}", key, hex::encode(value));
+                Ok(())
+            }
+            Self::Custom(kv) => {
+                let mut lock = kv.lock().await;
+                lock.set_value(key, value).await
+            }
+        }
     }
 
-    async fn list_values(&mut self, prefix: String) -> Result<Vec<String>, wit::KvError> {
-        todo!()
+    async fn list_values(&mut self, prefix: String) -> Result<Vec<String>, KvError> {
+        match self {
+            Self::Mock => todo!(),
+            Self::Custom(kv) => {
+                let mut lock = kv.lock().await;
+                lock.list_values(prefix).await
+            }
+        }
     }
 }

--- a/balius-sdk/src/qol.rs
+++ b/balius-sdk/src/qol.rs
@@ -17,6 +17,8 @@ pub enum Error {
     BadUtxo,
     #[error("event mismatch, expected {0}")]
     EventMismatch(String),
+    #[error("kv error: {0}")]
+    KV(wit::balius::app::kv::KvError),
     #[error("ledger error: {0}")]
     Ledger(wit::balius::app::ledger::LedgerError),
 }
@@ -35,6 +37,10 @@ impl From<Error> for wit::HandleError {
             Error::BadParams => wit::HandleError {
                 code: 2,
                 message: "bad params".to_owned(),
+            },
+            Error::KV(err) => wit::HandleError {
+                code: 3,
+                message: err.to_string(),
             },
             Error::Ledger(err) => wit::HandleError {
                 code: 4,
@@ -55,6 +61,12 @@ impl From<Error> for wit::HandleError {
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Error::Internal(error.to_string())
+    }
+}
+
+impl From<wit::balius::app::kv::KvError> for Error {
+    fn from(error: wit::balius::app::kv::KvError) -> Self {
+        Error::KV(error)
     }
 }
 

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -2,7 +2,11 @@ package balius:app@0.1.0;
 
 interface kv {
     type payload = list<u8>;
-    type kv-error = u32;
+    variant kv-error {
+        upstream(string),
+        internal(string),
+        not-found(string)
+    }
   
     get-value: func(key: string) -> result<payload, kv-error>;
     set-value: func(key: string, value: payload) -> result<_, kv-error>;


### PR DESCRIPTION
Also makes error handling from the KV module match the "ledger" module for ease of impl.

In my project, I found it's easiest to use sqlite for this (so I can share the same backing store across several backing instances). So even if there's a redb-backed implementation somewhere, I think being able to use a custom kv store is useful.
