### PR TITLE
Add extra fields to utxo events

### DIFF
--- a/balius-runtime/src/lib.rs
+++ b/balius-runtime/src/lib.rs
@@ -271,11 +271,15 @@ impl LoadedWorker {
                 }
 
                 let event = wit::Event::Utxo(wit::balius::app::driver::Utxo {
-                    block_hash: block_hash.clone(),
-                    block_height,
-                    tx_hash: tx_hash.clone(),
-                    index: index as u64,
-                    utxo: utxo.to_bytes(),
+                    block: wit::balius::app::driver::BlockRef {
+                        block_hash: block_hash.clone(),
+                        block_height,
+                    },
+                    body: utxo.to_bytes(),
+                    ref_: wit::balius::app::driver::TxoRef {
+                        tx_hash: tx_hash.clone(),
+                        txo_index: index as u32,
+                    },
                 });
 
                 for channel in channels {
@@ -299,11 +303,15 @@ impl LoadedWorker {
                 }
 
                 let event = wit::Event::UtxoUndo(wit::balius::app::driver::Utxo {
-                    block_hash: block_hash.clone(),
-                    block_height,
-                    tx_hash: tx_hash.clone(),
-                    index: index as u64,
-                    utxo: utxo.to_bytes(),
+                    block: wit::balius::app::driver::BlockRef {
+                        block_hash: block_hash.clone(),
+                        block_height,
+                    },
+                    body: utxo.to_bytes(),
+                    ref_: wit::balius::app::driver::TxoRef {
+                        tx_hash: tx_hash.clone(),
+                        txo_index: index as u32,
+                    },
                 });
 
                 for channel in channels {

--- a/balius-sdk/src/qol.rs
+++ b/balius-sdk/src/qol.rs
@@ -220,6 +220,10 @@ impl<T> std::ops::Deref for Json<T> {
 }
 
 pub struct Utxo<D> {
+    pub block_hash: Vec<u8>,
+    pub block_height: u64,
+    pub tx_hash: Vec<u8>,
+    pub index: u64,
     pub utxo: utxorpc_spec::utxorpc::v1alpha::cardano::TxOutput,
     pub datum: Option<D>,
 }
@@ -230,15 +234,26 @@ impl<D> TryFrom<wit::Event> for Utxo<D> {
     fn try_from(value: wit::Event) -> Result<Self, Self::Error> {
         use prost::Message;
 
-        let bytes = match value {
+        let utxo = match value {
             wit::Event::Utxo(x) => x,
             wit::Event::UtxoUndo(x) => x,
             _ => return Err(Error::EventMismatch("utxo|utxoundo".to_owned())),
         };
 
-        let utxo = Message::decode(bytes.as_slice()).map_err(|_| Self::Error::BadUtxo)?;
+        let block_hash = utxo.block_hash;
+        let block_height = utxo.block_height;
+        let tx_hash = utxo.tx_hash;
+        let index = utxo.index;
+        let utxo = Message::decode(utxo.utxo.as_slice()).map_err(|_| Self::Error::BadUtxo)?;
 
-        Ok(Utxo { utxo, datum: None })
+        Ok(Utxo {
+            block_hash,
+            block_height,
+            tx_hash,
+            index,
+            utxo,
+            datum: None,
+        })
     }
 }
 

--- a/balius-sdk/src/qol.rs
+++ b/balius-sdk/src/qol.rs
@@ -240,11 +240,11 @@ impl<D> TryFrom<wit::Event> for Utxo<D> {
             _ => return Err(Error::EventMismatch("utxo|utxoundo".to_owned())),
         };
 
-        let block_hash = utxo.block_hash;
-        let block_height = utxo.block_height;
-        let tx_hash = utxo.tx_hash;
-        let index = utxo.index;
-        let utxo = Message::decode(utxo.utxo.as_slice()).map_err(|_| Self::Error::BadUtxo)?;
+        let block_hash = utxo.block.block_hash;
+        let block_height = utxo.block.block_height;
+        let tx_hash = utxo.ref_.tx_hash;
+        let index = utxo.ref_.txo_index as u64;
+        let utxo = Message::decode(utxo.body.as_slice()).map_err(|_| Self::Error::BadUtxo)?;
 
         Ok(Utxo {
             block_hash,

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -78,9 +78,17 @@ interface driver {
     type timestamp = u64;
     type params = json;
 
+    record utxo {
+        block-hash: list<u8>,
+        block-height: u64,
+        tx-hash: list<u8>,
+        index: u64,
+        utxo: cbor,
+    }
+
     variant event {
-        utxo(cbor),
-        utxo-undo(cbor),
+        utxo(utxo),
+        utxo-undo(utxo),
         timer(timestamp),
         request(params),
         message(json),

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -78,12 +78,20 @@ interface driver {
     type timestamp = u64;
     type params = json;
 
-    record utxo {
+    record txo-ref {
+        tx-hash: list<u8>,
+        txo-index: u32,
+    }
+
+    record block-ref {
         block-hash: list<u8>,
         block-height: u64,
-        tx-hash: list<u8>,
-        index: u64,
-        utxo: cbor,
+    }
+
+    record utxo {
+        body: cbor,
+        ref: txo-ref,
+        block: block-ref,
     }
 
     variant event {


### PR DESCRIPTION
Add some fields to the wit definition of a "utxo" or "utxoundo" event:
 - `block-hash` is the hash of the utxo's block
 - `block-height` is the height of the utxo's block
 - `tx-hash`: is the hash of the tx which contains the output
 - `index` is the index of the output

As far as I can tell, other utxo-based chains would also have all of these fields associated with their utxos. So I think these all make sense to go in the wit, and don't need to be smuggled inside the utxo cbor (which is otherwise just straight-up utxorpc bytes)