### PR TITLE
Logging service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.12",
+ "tracing",
+ "tracing-subscriber",
  "utxorpc-spec 0.16.0",
  "wit-bindgen",
 ]

--- a/balius-runtime/src/logging/mod.rs
+++ b/balius-runtime/src/logging/mod.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::wit::balius::app::logging as wit;
+
+#[derive(Clone)]
+pub enum Logger {
+    Silent,
+    Tracing,
+    Custom(Arc<Mutex<dyn wit::Host + Send + Sync>>),
+}
+
+// need this to set the trace level at runtime
+macro_rules! dyn_event {
+    ($lvl:ident, $($arg:tt)+) => {
+        match $lvl {
+            ::tracing::Level::TRACE => ::tracing::trace!($($arg)+),
+            ::tracing::Level::DEBUG => ::tracing::debug!($($arg)+),
+            ::tracing::Level::INFO => ::tracing::info!($($arg)+),
+            ::tracing::Level::WARN => ::tracing::warn!($($arg)+),
+            ::tracing::Level::ERROR => ::tracing::error!($($arg)+),
+        }
+    };
+}
+
+#[async_trait]
+impl wit::Host for Logger {
+    async fn log(&mut self, level: wit::Level, context: String, message: String) {
+        match self {
+            Self::Silent => {}
+            Self::Tracing => {
+                let level = match level {
+                    wit::Level::Trace => tracing::Level::TRACE,
+                    wit::Level::Debug => tracing::Level::DEBUG,
+                    wit::Level::Info => tracing::Level::INFO,
+                    wit::Level::Warn => tracing::Level::WARN,
+                    wit::Level::Error => tracing::Level::ERROR,
+                    wit::Level::Critical => tracing::Level::ERROR,
+                };
+                dyn_event!(level, context, message);
+            }
+            Self::Custom(logger) => {
+                let mut lock = logger.lock().await;
+                lock.log(level, context, message).await
+            }
+        }
+    }
+}

--- a/balius-sdk/Cargo.toml
+++ b/balius-sdk/Cargo.toml
@@ -22,4 +22,6 @@ serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 serde_with = "3.9.0"
 thiserror = "2.0.11"
+tracing = "0.1.40"
+tracing-subscriber = "0.3"
 wit-bindgen = "0.39.0"

--- a/balius-sdk/src/lib.rs
+++ b/balius-sdk/src/lib.rs
@@ -22,5 +22,8 @@ pub mod _internal;
 /// Quality of life features to make the SDK more ergonomic
 mod qol;
 
+/// A tracing implementation which sends logs to the server
+pub mod logging;
+
 pub use _internal::Worker;
 pub use qol::*;

--- a/balius-sdk/src/logging.rs
+++ b/balius-sdk/src/logging.rs
@@ -1,0 +1,46 @@
+use tracing_subscriber::{
+    field::VisitOutput,
+    fmt::format::{DefaultVisitor, Writer},
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+    Layer, Registry,
+};
+
+#[derive(Default)]
+pub struct BaliusLayer {}
+
+impl BaliusLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for BaliusLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let context = event.metadata().target();
+        let level = match *event.metadata().level() {
+            tracing::Level::TRACE => crate::wit::balius::app::logging::Level::Trace,
+            tracing::Level::DEBUG => crate::wit::balius::app::logging::Level::Debug,
+            tracing::Level::INFO => crate::wit::balius::app::logging::Level::Info,
+            tracing::Level::WARN => crate::wit::balius::app::logging::Level::Warn,
+            tracing::Level::ERROR => crate::wit::balius::app::logging::Level::Error,
+        };
+
+        let mut message = String::new();
+        let mut visitor = DefaultVisitor::new(Writer::new(&mut message), false);
+        event.record(&mut visitor);
+        if visitor.finish().is_err() {
+            message = "[error formatting message]".to_string();
+        }
+
+        crate::wit::balius::app::logging::log(level, context, &message);
+    }
+}
+
+pub fn init() {
+    Registry::default().with(BaliusLayer::new()).init();
+}

--- a/balius-sdk/src/logging.rs
+++ b/balius-sdk/src/logging.rs
@@ -31,7 +31,7 @@ impl<S: tracing::Subscriber> Layer<S> for BaliusLayer {
         };
 
         let mut message = String::new();
-        let mut visitor = DefaultVisitor::new(Writer::new(&mut message), false);
+        let mut visitor = DefaultVisitor::new(Writer::new(&mut message), true);
         event.record(&mut visitor);
         if visitor.finish().is_err() {
             message = "[error formatting message]".to_string();

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -57,6 +57,41 @@ interface ledger {
     read-params: func() -> result<json, ledger-error>;
 }
 
+/// This is identical to the WASI logging interface 
+interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+
+       /// Describes messages indicating fatal errors.
+       critical,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string);
+}
+
 interface sign {
     type payload = list<u8>;
     type signature = list<u8>;
@@ -153,6 +188,7 @@ interface driver {
 world worker {
     import kv;
     import broadcast;
+    import logging;
     import sign;
     import submit;
     import ledger;


### PR DESCRIPTION
Add a `logging` service to balius, identical to the WASI logging API.

Inside of a balius worker, you can call `balius::logging::init()` to initialize the logger (or use the `BaliusLayer` as part of a fancier logging setup). It registers a `tracing` subscriber, so dapps can just call `info!(foo = "bar", "whatever")` to log messages.

The runtime has three logger implementations available: `Silent` (logs nothing), `Tracing` (emits a `tracing` event), or `Custom` (does whatever the caller wants). If they don't select one, the runtime uses `Silent` by default.
