### PR TITLE
Add signer.get-public-key

### DIFF
--- a/balius-runtime/src/sign/mod.rs
+++ b/balius-runtime/src/sign/mod.rs
@@ -34,4 +34,18 @@ impl wit::Host for Signer {
             }
         }
     }
+
+    async fn get_public_key(
+        &mut self,
+        key_name: String,
+        algorithm: String,
+    ) -> Result<wit::PublicKey, wit::SignError> {
+        match self {
+            Self::InMemory(signer) => signer.get_public_key(&key_name, &algorithm),
+            Self::Custom(signer) => {
+                let mut lock = signer.lock().await;
+                lock.get_public_key(key_name, algorithm).await
+            }
+        }
+    }
 }

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -95,6 +95,7 @@ interface logging {
 interface sign {
     type payload = list<u8>;
     type signature = list<u8>;
+    type public-key = list<u8>;
     variant sign-error {
         internal(string),
         key-not-found(string),
@@ -102,6 +103,7 @@ interface sign {
     }
 
     sign-payload: func(key-name: string, algorithm: string, payload: payload) -> result<signature, sign-error>;
+    get-public-key: func(key-name: string, algorithm: string) -> result<public-key, sign-error>;
 }
 
 interface submit {


### PR DESCRIPTION
We realized that for our use case, workers need to recognize "their own" public keys on-chain. This adds a `get-public-key` method to the signer interface which... gets a public key. Simple as.