### PR TITLE
Balius tx events

### DIFF
--- a/balius-runtime/src/lib.rs
+++ b/balius-runtime/src/lib.rs
@@ -146,6 +146,26 @@ pub enum ChainPoint {
 
 pub type LogSeq = u64;
 
+pub enum TxInput {
+    Cardano(utxorpc::spec::cardano::TxInput),
+}
+
+impl TxInput {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        use prost::Message;
+
+        match self {
+            Self::Cardano(tx_input) => tx_input.encode_to_vec(),
+        }
+    }
+
+    pub fn address(&self) -> Option<Vec<u8>> {
+        match self {
+            Self::Cardano(tx_input) => tx_input.as_output.as_ref().map(|o| o.address.to_vec()),
+        }
+    }
+}
+
 pub enum Utxo {
     Cardano(utxorpc::spec::cardano::TxOutput),
 }
@@ -156,6 +176,12 @@ impl Utxo {
 
         match self {
             Self::Cardano(utxo) => utxo.encode_to_vec(),
+        }
+    }
+
+    pub fn address(&self) -> Option<Vec<u8>> {
+        match self {
+            Self::Cardano(utxo) => Some(utxo.address.to_vec()),
         }
     }
 }
@@ -170,6 +196,15 @@ impl Tx {
             Self::Cardano(tx) => tx.hash.clone().into(),
         }
     }
+    pub fn inputs(&self) -> Vec<TxInput> {
+        match self {
+            Self::Cardano(tx) => tx
+                .inputs
+                .iter()
+                .map(|i| TxInput::Cardano(i.clone()))
+                .collect(),
+        }
+    }
     pub fn outputs(&self) -> Vec<Utxo> {
         match self {
             Self::Cardano(tx) => tx
@@ -177,6 +212,13 @@ impl Tx {
                 .iter()
                 .map(|o| Utxo::Cardano(o.clone()))
                 .collect(),
+        }
+    }
+    pub fn to_bytes(&self) -> Vec<u8> {
+        use prost::Message;
+
+        match self {
+            Self::Cardano(tx) => tx.encode_to_vec(),
         }
     }
 }
@@ -296,8 +338,23 @@ impl LoadedWorker {
         let block_height = block.height();
         for tx in block.txs() {
             let tx_hash = tx.hash();
+            let channels = self.wasm_store.data().router.find_tx_targets(&tx);
+            if !channels.is_empty() {
+                let event = wit::Event::Tx(wit::balius::app::driver::Tx {
+                    block: wit::balius::app::driver::BlockRef {
+                        block_hash: block_hash.clone(),
+                        block_height,
+                    },
+                    body: tx.to_bytes(),
+                    hash: tx_hash.clone(),
+                });
+                for channel in channels {
+                    self.acknowledge_event(channel, &event).await?;
+                }
+            }
+
             for (index, utxo) in tx.outputs().into_iter().enumerate() {
-                let channels = self.wasm_store.data().router.find_utxo_targets(&utxo)?;
+                let channels = self.wasm_store.data().router.find_utxo_targets(&utxo);
                 if channels.is_empty() {
                     continue;
                 }
@@ -328,8 +385,8 @@ impl LoadedWorker {
         let block_height = block.height();
         for tx in block.txs() {
             let tx_hash = tx.hash();
-            for (index, utxo) in tx.outputs().into_iter().enumerate() {
-                let channels = self.wasm_store.data().router.find_utxo_targets(&utxo)?;
+            for (index, utxo) in tx.outputs().into_iter().enumerate().rev() {
+                let channels = self.wasm_store.data().router.find_utxo_targets(&utxo);
                 if channels.is_empty() {
                     continue;
                 }
@@ -346,6 +403,21 @@ impl LoadedWorker {
                     },
                 });
 
+                for channel in channels {
+                    self.acknowledge_event(channel, &event).await?;
+                }
+            }
+
+            let channels = self.wasm_store.data().router.find_tx_targets(&tx);
+            if !channels.is_empty() {
+                let event = wit::Event::TxUndo(wit::balius::app::driver::Tx {
+                    block: wit::balius::app::driver::BlockRef {
+                        block_hash: block_hash.clone(),
+                        block_height,
+                    },
+                    body: tx.to_bytes(),
+                    hash: tx_hash.clone(),
+                });
                 for channel in channels {
                     self.acknowledge_event(channel, &event).await?;
                 }

--- a/examples/wallet/offchain/src/lib.rs
+++ b/examples/wallet/offchain/src/lib.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use balius_sdk::{Ack, WorkerResult};
+use balius_sdk::{Ack, UtxoMatcher, WorkerResult};
 use balius_sdk::{Config, FnHandler, Utxo, Worker};
 use serde::{Deserialize, Serialize};
 
@@ -50,13 +50,7 @@ fn handle_utxo(_: Config<WalletConfig>, utxo: Utxo<Datum>) -> WorkerResult<Ack> 
 
 #[balius_sdk::main]
 fn main() -> Worker {
-    Worker::new().with_utxo_handler(
-        balius_sdk::wit::balius::app::driver::UtxoPattern {
-            address: None,
-            token: None,
-        },
-        FnHandler::from(handle_utxo),
-    )
+    Worker::new().with_utxo_handler(UtxoMatcher::all(), FnHandler::from(handle_utxo))
 }
 
 // #[cfg(test)]
@@ -82,7 +76,8 @@ fn main() -> Worker {
 //         let cbor = pallas_codec::minicbor::to_vec(&output).unwrap();
 //
 //         let test_utxos: HashMap<_, _> = vec![(
-//             "f7d3837715680f3a170e99cd202b726842d97f82c05af8fcd18053c64e33ec4f#0"
+//
+// "f7d3837715680f3a170e99cd202b726842d97f82c05af8fcd18053c64e33ec4f#0"
 //                 .parse()
 //                 .unwrap(),
 //             cbor,

--- a/wit/balius.wit
+++ b/wit/balius.wit
@@ -306,7 +306,15 @@ interface driver {
         block: block-ref,
     }
 
+    record tx {
+        body: cbor,
+        hash: list<u8>,
+        block: block-ref,
+    }
+
     variant event {
+        tx(tx),
+        tx-undo(tx),
         utxo(utxo),
         utxo-undo(utxo),
         timer(timestamp),
@@ -333,6 +341,8 @@ interface driver {
     type topic = string;
 
     variant event-pattern {
+        tx(utxo-pattern),
+        tx-undo(utxo-pattern),
         utxo(utxo-pattern),
         utxo-undo(utxo-pattern),
         timer(timer-interval),


### PR DESCRIPTION
Added support for `Tx` and `TxUndo` events. These fire at the transaction level, and include the entire transaction. This allows us to write workers which react to a TXO getting spent.

TX events use the same `UtxoPattern` structure as UTXO events; the semantics are that a TX is matched if that "UTXO pattern" matches any of its inputs or outputs. That way, you can provide an address to react to any transaction which impacts that address.