### PR TITLE
feat: support building without openssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3418,6 +3419,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -5205,6 +5207,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/balius-runtime/Cargo.toml
+++ b/balius-runtime/Cargo.toml
@@ -29,7 +29,7 @@ tokio-util = "0.7.12"
 prost = "0.13"
 object_store = { version = "0.12.0", features = ["fs"] }
 url = "2.5.4"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", default-features = false, features = ["http2", "charset", "macos-system-configuration"] }
 opentelemetry = { version = "0.29.1", features = ["metrics", "trace"] }
 rand = "0.8.5"
 
@@ -39,7 +39,13 @@ wat = "1"
 wit-component = "0.225"
 
 [features]
+default = ["default-tls"]
 http = ["object_store/http"]
 aws = ["object_store/aws"]
 gcp = ["object_store/gcp"]
 azure = ["object_store/azure"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]


### PR DESCRIPTION
The reqwest library lets you configure which TLS provider to use. By default, it uses something called `native-tls`, which depends on openssl at runtime.

Linking against openssl makes it annoying to build and run docker containers. Reqwest lets you use features to link against other tls providers.

This PR adds features to balius (identical to the features exposed by reqwest) which let you configure its TLS setup too. You can disable default features and enable `rustls-tls` to remove the openssl dep.